### PR TITLE
Feat. 공용모달 id 값 전달 방식 변경

### DIFF
--- a/src/components/Form/reviewForm/ReviewForm.tsx
+++ b/src/components/Form/reviewForm/ReviewForm.tsx
@@ -15,14 +15,11 @@ type initialStateType = {
   content: string;
 };
 
-type reviewFormProps = {
-  reviewed_id: string;
-};
-
-const ReviewForm = ({ reviewed_id }: reviewFormProps) => {
+const ReviewForm = () => {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const loginUser = useSelector((state: RootState) => state.user.user);
+  const { targetId: tutorId } = useSelector((state: RootState) => state.modal);
 
   const mutation = useMutation(reviewRequest, {
     onSuccess: () => {
@@ -70,9 +67,13 @@ const ReviewForm = ({ reviewed_id }: reviewFormProps) => {
     e.preventDefault();
 
     if (!loginUser) return;
+    if (!tutorId) {
+      console.log('지정할 tutor의 Id가 없습니다.');
+      return;
+    }
 
     const newReview: reviews = {
-      reviewed_id: reviewed_id,
+      reviewed_id: tutorId,
       user_id: loginUser?.id,
       author: loginUser?.username,
       title: title as string,

--- a/src/components/Form/reviewForm/ReviewUpdateForm.tsx
+++ b/src/components/Form/reviewForm/ReviewUpdateForm.tsx
@@ -15,14 +15,11 @@ type initialStateType = {
   content: string;
 };
 
-type reviewFormProps = {
-  reviewed_id: string;
-};
-
-const ReviewUpdateForm = ({ reviewed_id }: reviewFormProps) => {
+const ReviewUpdateForm = () => {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const loginUser = useSelector((state: RootState) => state.user.user);
+  const { targetId: tutorId } = useSelector((state: RootState) => state.modal);
 
   const prevReview: Tables<'review'> = useSelector((state: RootState) => state.review);
 
@@ -72,9 +69,13 @@ const ReviewUpdateForm = ({ reviewed_id }: reviewFormProps) => {
     e.preventDefault();
 
     if (!loginUser) return;
+    if (!tutorId) {
+      console.log('수정하실 tutorId ID를 찾을 수 없습니다.');
+      return;
+    }
 
     const updatedReview: reviews = {
-      reviewed_id: reviewed_id,
+      reviewed_id: tutorId,
       user_id: loginUser?.id,
       author: loginUser?.username,
       title: title as string,

--- a/src/components/modal/GlobalModal.tsx
+++ b/src/components/modal/GlobalModal.tsx
@@ -5,7 +5,7 @@ import { RootState } from '../../redux/config/configStore';
 import ModalPortal from './ModalPortal';
 
 const GlobalModal = () => {
-  const { type, isOpen, targetId } = useSelector((state: RootState) => state.modal);
+  const { type, isOpen } = useSelector((state: RootState) => state.modal);
   if (!isOpen) return;
 
   const MODAL_TYPES = {
@@ -31,11 +31,11 @@ const GlobalModal = () => {
     },
     {
       type: MODAL_TYPES.reviewCreate,
-      component: targetId !== undefined ? <ReviewForm reviewed_id={targetId} /> : null,
+      component: <ReviewForm />,
     },
     {
       type: MODAL_TYPES.reviewUpdate,
-      component: targetId !== undefined ? <ReviewUpdateForm reviewed_id={targetId} /> : null,
+      component: <ReviewUpdateForm />,
     },
   ];
 

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -44,24 +44,6 @@ const Detail = () => {
 
   const loginUser = useSelector((state: RootState) => state.user.user);
 
-  // StarRate
-
-  const starRating = (currentRate: number) => {
-    const MAX_STAR_RATE = 5;
-    let starCount = Math.floor(currentRate);
-
-    //소수점 찾기
-    let halfStarRate = currentRate - starCount;
-
-    if (currentRate - halfStarRate >= 0.5) {
-      return <img src={starHalf} alt={`Half Star`} />;
-    } else {
-      return <img src={starEmpty} alt={`Empty Star`} />;
-    }
-  };
-
-  //
-
   const queryClient = useQueryClient();
 
   const mutationReviewDelete = useMutation(reviewDelete, {

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -24,11 +24,11 @@ const Detail = () => {
   const { id } = useParams();
 
   // newReview에 사용할 targeId 업데이트
-  useEffect(() => {
-    if (id) {
-      dispatch(setTargetId(id));
-    }
-  }, [id]);
+  // useEffect(() => {
+  //   if (id) {
+  //     dispatch(setTargetId(id));
+  //   }
+  // }, [id]);
   const navigate = useNavigate();
 
   const { data: profiles, isLoading: profilesLoading, isError: profilesError } = useQuery(['profiles'], fetchData);
@@ -80,15 +80,15 @@ const Detail = () => {
 
   // 모달
   const handleOpen = () => {
-    dispatch(openModal('report'));
+    dispatch(openModal({ type: 'report' }));
   };
 
   const handleOpenReviewCreateForm = () => {
-    dispatch(openModal('reviewCreate'));
+    dispatch(openModal({ type: 'reviewCreate', targetId: id }));
   };
 
   const handleOpenReviewUpdateForm = () => {
-    dispatch(openModal('reviewUpdate'));
+    dispatch(openModal({ type: 'reviewUpdate', targetId: id }));
   };
 
   // 리뷰 Delete

--- a/src/redux/modules/ModalSlice.ts
+++ b/src/redux/modules/ModalSlice.ts
@@ -2,8 +2,8 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 type ModalState = {
   type: string;
-  isOpen: boolean;
-  targetId?: string;
+  isOpen?: boolean;
+  targetId?: string | null;
 };
 
 const initialState: ModalState = {
@@ -16,8 +16,10 @@ const modalSlice = createSlice({
   name: 'modal',
   initialState,
   reducers: {
-    openModal: (state, action: PayloadAction<string>) => {
-      state.type = action.payload;
+    openModal: (state, action: PayloadAction<ModalState>) => {
+      state.type = action.payload.type;
+      state.targetId = action.payload.targetId;
+
       state.isOpen = true;
     },
 


### PR DESCRIPTION
기존에 사용하시던 분은 
`dispatch(openModal('report'))` 하실 때 매개변수를 `dispatch(openModal( {type: 'report'} ))` 이런 형태로 넣어주셔야 합니다!


***기존방식**
dispatch로 setTargetId를 사용하여 redux의 state를 변경
ex) dispatch(setTargetId(id값)); 


***변경된 방식** 
openModald을 사용하실 때 한번에 type과 targetID를 넘겨주는 방식으로 변경했습니다.
넘겨주실 id가 없는 경우 그냥 객체 형태로 type 지정해서 사용하시면 됩니다!
ex) dispatch(openModal({type: '사용하실 모달 타입', targetId: '사용하실 TargetId' } ) )